### PR TITLE
Print log message to make sure that users know where to go

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -6,4 +6,5 @@ server.set('port', process.env.PORT || 3000);
 
 var server = server.listen(server.get('port'), function() {
   console.log('Express server listening on port ' + server.address().port);
+  console.log('Please visit http://localhost:' + server.address().port + '/app/index.html');
 });


### PR DESCRIPTION
Great work. This small patch just prints out the useful tip on startup of the server that they should open up the starting page of ODF Explorer at http://localhost:3000/app/index.html .

Otherwise they might instead go to http://localhost:3000, be confused by the error message and give up. Of course the readme also contains this information, but users don't always follow that good advice consistently and will think they understand everything.
